### PR TITLE
using ntdll.dll for RtlZeroMemory instead of kernel32.dll

### DIFF
--- a/Isopoh.Cryptography.SecureArray/DefaultWindowsSecureArraycall.cs
+++ b/Isopoh.Cryptography.SecureArray/DefaultWindowsSecureArraycall.cs
@@ -309,8 +309,9 @@ namespace Isopoh.Cryptography.SecureArray
             uint minWorkingSetSize,
             uint maxWorkingSetSize,
             uint flags);
-
-        [DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi)]
+        // FROM https://github.com/dotnet/coreclr/pull/5554/commits/2a1187d9344639cc343d1e227ee03c6d1eb1e9ca
+        //[DllImport("kernel32.dll", CallingConvention = CallingConvention.Winapi)]
+        [DllImport("ntdll.dll", CallingConvention = CallingConvention.Winapi)]
         private static extern void RtlZeroMemory(IntPtr ptr, UIntPtr cnt);
 
         [DllImport(


### PR DESCRIPTION
we're getting 

```
Unable to find an entry point named 'RtlZeroMemory' in DLL 'kernel32.dll'.
   at Isopoh.Cryptography.SecureArray.DefaultWindowsSecureArrayCall.RtlZeroMemory(Int
```

when using this lib with dotnetcore 3 on mcr.microsoft.com/dotnet/core/aspnet:3.0.0-nanoserver-1809

fix was inspired by
https://github.com/dotnet/coreclr/pull/5554/commits/2a1187d9344639cc343d1e227ee03c6d1eb1e9ca

please consider merging

thanks
