### PR TITLE
Improved doc explanation for memoryCost

### DIFF
--- a/Isopoh.Cryptography.Argon2/Argon2.Helpers.cs
+++ b/Isopoh.Cryptography.Argon2/Argon2.Helpers.cs
@@ -48,7 +48,7 @@ namespace Isopoh.Cryptography.Argon2
         /// The time cost to use. Defaults to 3.
         /// </param>
         /// <param name="memoryCost">
-        /// The memory cost to use. Defaults to 65536 (64K).
+        /// The memory cost to use. Defaults to 65536 (65536 * 1024 = 64MB).
         /// </param>
         /// <param name="parallelism">
         /// The parallelism to use. Default to 1 (single threaded).
@@ -110,7 +110,7 @@ namespace Isopoh.Cryptography.Argon2
         /// The time cost to use. Defaults to 3.
         /// </param>
         /// <param name="memoryCost">
-        /// The memory cost to use. Defaults to 65536 (64K).
+        /// The memory cost to use. Defaults to 65536 (65536 * 1024 = 64MB).
         /// </param>
         /// <param name="parallelism">
         /// The parallelism to use. Default to 1 (single threaded).
@@ -178,7 +178,7 @@ namespace Isopoh.Cryptography.Argon2
         /// The time cost to use. Defaults to 3.
         /// </param>
         /// <param name="memoryCost">
-        /// The memory cost to use. Defaults to 65536 (64K).
+        /// The memory cost to use. Defaults to 65536 (65536 * 1024 = 64MB).
         /// </param>
         /// <param name="parallelism">
         /// The parallelism to use. Default to 1 (single threaded).


### PR DESCRIPTION
This merge aims to improve and better explain the memoryCost documentation

65536 is not 64K but 64KB
64K (64,000) * 1024 = 64MiB (65,536,000)
64KB (65536) * 1024 = 64MB

This clears up any confusion and resolves issue #17 