### PR TITLE
Blazor WebAssembly on .net 5 fix

### DIFF
--- a/Isopoh.Cryptography.SecureArray/DefaultWebSecureArrayCall.cs
+++ b/Isopoh.Cryptography.SecureArray/DefaultWebSecureArrayCall.cs
@@ -20,9 +20,9 @@ namespace Isopoh.Cryptography.SecureArray
         public DefaultWebSecureArrayCall()
             : base(WebZero, WebLockMemory, WebUnlockMemory)
         {
-            if (RuntimeInformation.OSDescription != "web")
+            if (RuntimeInformation.OSDescription != "web" && RuntimeInformation.OSDescription != "Browser")
             {
-                throw new DllNotFoundException($"Running on \"{RuntimeInformation.OSDescription}\", not \"web\".");
+                throw new DllNotFoundException($"Running on \"{RuntimeInformation.OSDescription}\", not \"web\" or \"Browser\".");
             }
         }
 


### PR DESCRIPTION
Blazor WebAssembly returns value Browser for RuntimeInformation.OSDescription when running on .Net 5.0
fixes #33