### PR TITLE
Argon2Config: disallow null salt

### DIFF
--- a/lib/Isopoh.Cryptography.Argon2/Argon2.DumpTestVector.cs
+++ b/lib/Isopoh.Cryptography.Argon2/Argon2.DumpTestVector.cs
@@ -46,8 +46,8 @@ namespace Isopoh.Cryptography.Argon2
                     : BitConverter.ToString(hasher.config.Password ?? Array.Empty<byte>()).ToLowerInvariant().Replace('-', ' ');
                 streamOut.WriteLine($"Password[{hasher.config.Password?.Length ?? -1}]: {pwText} ");
                 streamOut.WriteLine(
-                    $"Salt[{hasher.config.Salt?.Length ?? 0}]: "
-                    + $"{(hasher.config.Salt == null ? string.Empty : BitConverter.ToString(hasher.config.Salt).ToLowerInvariant().Replace('-', ' '))} ");
+                    $"Salt[{hasher.config.Salt.Length}]: "
+                    + $"{BitConverter.ToString(hasher.config.Salt).ToLowerInvariant().Replace('-', ' ')} ");
                 streamOut.WriteLine(
                     $"Secret[{hasher.config.Secret?.Length ?? 0}]: "
                     + $"{(hasher.config.Secret == null ? string.Empty : BitConverter.ToString(hasher.config.Secret).ToLowerInvariant().Replace('-', ' '))} ");

--- a/lib/Isopoh.Cryptography.Argon2/Argon2.InitFillFinal.cs
+++ b/lib/Isopoh.Cryptography.Argon2/Argon2.InitFillFinal.cs
@@ -64,12 +64,9 @@ namespace Isopoh.Cryptography.Argon2
                 }
             }
 
-            Store32(value, this.config.Salt?.Length ?? 0);
+            Store32(value, this.config.Salt.Length);
             blakeHash.Update(value);
-            if (this.config.Salt != null)
-            {
-                blakeHash.Update(this.config.Salt);
-            }
+            blakeHash.Update(this.config.Salt);
 
             Store32(value, this.config.Secret?.Length ?? 0);
             blakeHash.Update(value);

--- a/lib/Isopoh.Cryptography.Argon2/Argon2Config.cs
+++ b/lib/Isopoh.Cryptography.Argon2/Argon2Config.cs
@@ -7,6 +7,7 @@
 namespace Isopoh.Cryptography.Argon2
 {
     using System;
+    using System.Security.Cryptography;
     using Isopoh.Cryptography.SecureArray;
 
     /// <summary>
@@ -65,13 +66,24 @@ namespace Isopoh.Cryptography.Argon2
         #nullable restore
 
         /// <summary>
-        /// Gets or sets the salt used in the password hash. If non-null, must be at least 8 bytes.
+        /// Gets or sets the salt used in the password hash. Must be at least 8 bytes.
+        /// If no salt is given, a random one will be generated.
         /// </summary>
         #nullable enable
-        public byte[]? Salt
+        public byte[] Salt
         #nullable restore
         {
-            get => this.salt;
+            get
+            {
+                if (this.salt == null)
+                {
+                    this.salt = new byte[16];
+                    using var randomNumberGenerator = RandomNumberGenerator.Create();
+                    randomNumberGenerator.GetBytes(this.salt);
+                }
+
+                return this.salt;
+            }
 
             set
             {

--- a/lib/Isopoh.Cryptography.Argon2/EncodeExtension.cs
+++ b/lib/Isopoh.Cryptography.Argon2/EncodeExtension.cs
@@ -107,11 +107,6 @@ namespace Isopoh.Cryptography.Argon2
 ////                dst.Append(config.AssociatedData.ToB64String());
 ////            }
 
-            if (config.Salt == null || config.Salt.Length == 0)
-            {
-                return dst.ToString();
-            }
-
             dst.Append('$');
             dst.Append(config.Salt.ToB64String());
 

--- a/test/Isopoh.Cryptography.Test/UnitTests.cs
+++ b/test/Isopoh.Cryptography.Test/UnitTests.cs
@@ -14,6 +14,7 @@ using Argon2;
 using SecureArray;
 using Xunit;
 using Xunit.Abstractions;
+using System.Text;
 
 /// <summary>
 /// Unit tests for Isopoh.Cryptography.Argon2.
@@ -136,5 +137,17 @@ public class UnitTests
     {
         var (passed, text) = HighMemoryCost.Test(this.output);
         Assert.True(passed, text);
+    }
+
+    [Fact]
+    public void ConfigWithoutSalt()
+    {
+        string password = "password";
+        var config = new Argon2Config()
+        {
+            Password = Encoding.UTF8.GetBytes(password),
+        };
+        string hash = Argon2.Hash(config);
+        Assert.True(Argon2.Verify(hash, password));
     }
 }

--- a/test/TestLib/ThreadsDontMatter.cs
+++ b/test/TestLib/ThreadsDontMatter.cs
@@ -41,6 +41,7 @@ public static class ThreadsDontMatter
             Type = Argon2Type.DataIndependentAddressing,
             Version = Argon2Version.Nineteen,
             Password = passwordBytes,
+            Salt = configA.Salt,
             TimeCost = 3,
             MemoryCost = 32,
             Lanes = 4,


### PR DESCRIPTION
This fixes https://github.com/mheyman/Isopoh.Cryptography.Argon2/issues/52

Section 3.1 of the spec https://www.password-hashing.net/argon2-specs.pdf specfies a minimum length of 8 for the salt. The reference implementation does not allow empty salts either. Although line 423 in core.c looks like it allows a null salt if the length is zero, the zero length will then actually be rejected by the condition in line 428.

This change makes Argon2Config generate a random salt with the recommended default length of 16 when the getter of the `Salt` property is called without setting a salt beforehand. This allows the property to be non-nullable, and cases dealing with a spec-violating null salt be removed.

Removal of the null-handling case also gets rid of an erroneous early bailout in that case from the encoder. That had the effect of omitting the hash from the encoded string when no salt was given (#52). Note that just skipping the salt would not work, because the decoder would then interpret the hash as salt instead.

The test in ThreadsDontMatter.cs had to be changed so that both configs use the same salt. Note that before the fix that test didn't actually test anything because of the bug mentioned above: an empty salt would cause the hash to be omitted from the encoded string as well.